### PR TITLE
Add translation demo skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# fanyi
+# Translation System Skeleton
+
+This repository provides a simple PHP-based example of a translation system. It demonstrates a minimal UI with light/dark themes, automatic translation on paste, and a placeholder API call for actual translation logic.
+
+**Note**: Real machine translation requires external services or libraries. This project only includes placeholders for those API calls.
+
+## Files
+
+- `index.php` – main UI.
+- `translate.php` – endpoint that performs the translation (placeholder implementation).
+- `assets/style.css` – basic CSS with theme support.
+- `assets/script.js` – frontend logic for automatic translation and theme switching.
+
+## Running locally
+
+1. Ensure PHP 7.0+ is installed.
+2. Start the PHP built-in server for testing:
+   ```bash
+   php -S localhost:8000
+   ```
+3. Open `http://localhost:8000` in your browser.
+
+For deployment on environments such as BT panel (宝塔), place the repository contents in your site directory and configure PHP accordingly. The project does not use any frameworks.
+
+## Placeholder translation logic
+
+The backend script `translate.php` currently contains a `TODO` section where an actual machine translation API should be integrated. Insert your API keys and logic according to the provider's documentation.

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,28 @@
+window.addEventListener('DOMContentLoaded', () => {
+    const themeToggle = document.getElementById('themeToggle');
+    const body = document.body;
+    themeToggle.addEventListener('click', () => {
+        body.classList.toggle('dark');
+        body.classList.toggle('light');
+    });
+
+    const textInput = document.getElementById('text');
+    textInput.addEventListener('paste', () => {
+        setTimeout(() => autoTranslate(), 10);
+    });
+});
+
+function autoTranslate() {
+    const text = document.getElementById('text').value;
+    const from = document.getElementById('from').value;
+    const to = document.getElementById('to').value;
+    fetch('translate.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: `text=${encodeURIComponent(text)}&from=${from}&to=${to}`
+    })
+    .then(res => res.text())
+    .then(data => {
+        document.getElementById('result').textContent = data;
+    });
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,32 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}
+
+.dark {
+    --bg-color: #222;
+    --text-color: #f5f5f5;
+}
+
+.light {
+    --bg-color: #fff;
+    --text-color: #222;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+textarea {
+    width: 100%;
+    height: 150px;
+}
+
+select, button {
+    margin-top: 10px;
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,36 @@
+<?php
+?>
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Translation Demo</title>
+    <link rel="stylesheet" href="assets/style.css">
+</head>
+<body class="light">
+<div class="container">
+    <h1>Translation Demo</h1>
+    <button id="themeToggle">Toggle Theme</button>
+    <div>
+        <label>From
+            <select id="from">
+                <option value="zh">Chinese</option>
+                <option value="ug">Uyghur</option>
+                <option value="kk">Kazakh</option>
+            </select>
+        </label>
+        <label>To
+            <select id="to">
+                <option value="ug">Uyghur</option>
+                <option value="kk">Kazakh</option>
+                <option value="zh">Chinese</option>
+            </select>
+        </label>
+    </div>
+    <textarea id="text" placeholder="Enter text here"></textarea>
+    <pre id="result"></pre>
+</div>
+<script src="assets/script.js"></script>
+</body>
+</html>

--- a/translate.php
+++ b/translate.php
@@ -1,0 +1,17 @@
+<?php
+header('Content-Type: text/plain; charset=utf-8');
+
+$text = $_POST['text'] ?? '';
+$from = $_POST['from'] ?? 'zh';
+$to   = $_POST['to'] ?? 'ug';
+
+if (trim($text) === '') {
+    echo "";
+    exit;
+}
+
+// TODO: Replace the following placeholder with real translation logic.
+// Example: call external API using cURL with your credentials.
+$result = "[translated $from->$to] " . $text;
+
+echo $result;


### PR DESCRIPTION
## Summary
- replace README with instructions
- add light/dark theme example in CSS/JS
- add simple `index.php` UI and `translate.php` endpoint

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68496c9d22a8832db4a390b8ce0ed2a0